### PR TITLE
Renaming button to New Post

### DIFF
--- a/Controls/App_LocalResources/ManagementPanel.ascx.resx
+++ b/Controls/App_LocalResources/ManagementPanel.ascx.resx
@@ -121,7 +121,7 @@
     <value>Cancel</value>
   </data>
   <data name="cmdBlog.Text" xml:space="preserve">
-    <value>Blog!</value>
+    <value>New Post!</value>
   </data>
   <data name="cmdCopyModule.Text" xml:space="preserve">
     <value>Copy Module</value>


### PR DESCRIPTION
The button to create a new post "Blog!" is confusing for some users. A better name "New Post!" is suggested here, especially when the adjacent button is "Edit Post"