### PR TITLE
Use user/portal time zone for post published token

### DIFF
--- a/Components/Common/Globals.vb
+++ b/Components/Common/Globals.vb
@@ -54,10 +54,6 @@ Namespace Common
    Return TimeZoneInfo.ConvertTimeFromUtc(utcTime, TimeZone)
   End Function
 
-  Public Shared Function UtcToLocalTime(utcTime As Date) As Date
-   Return Date.SpecifyKind(utcTime, DateTimeKind.Utc).ToLocalTime
-  End Function
-
   Public Shared Function ParseDate(DateString As String, Culture As String) As DateTime
    Dim dtf As System.Globalization.DateTimeFormatInfo = New System.Globalization.CultureInfo(Culture, False).DateTimeFormat
    Try

--- a/Components/Entities/Posts/PostInfo_Interfaces.vb
+++ b/Components/Entities/Posts/PostInfo_Interfaces.vb
@@ -123,7 +123,11 @@ Namespace Entities.Posts
     Case "publishedyesno"
      Return PropertyAccess.Boolean2LocalizedYesNo(Me.Published, formatProvider)
     Case "publishedondate"
-     Return UtcToLocalTime(PublishedOnDate).ToString(OutputFormat, formatProvider)
+     Dim userTimeZone As TimeZoneInfo = portalSettings.TimeZone
+     If AccessingUser.Profile.PreferredTimeZone IsNot Nothing Then
+       userTimeZone = AccessingUser.Profile.PreferredTimeZone 
+     End If
+     Return UtcToLocalTime(PublishedOnDate, userTimeZone).ToString(OutputFormat, formatProvider)
     Case "allowcomments"
      Return Me.AllowComments.ToString
     Case "allowcommentsyesno"


### PR DESCRIPTION
The `[Post:PublishdOnDate]` token uses the system time, rather than the user's time, which makes the display inconsistent.

I'm also removing the `UtcToLocalTime` override that doesn't take a `TimeZoneInfo`, since it's no longer used (and, IMO, not helpful)