### PR TITLE
Update published token

### DIFF
--- a/App_LocalResources/PostEdit.ascx.resx
+++ b/App_LocalResources/PostEdit.ascx.resx
@@ -167,7 +167,7 @@
     <value>Select to publish. Deselect to unpublish (i.e. to make invisible to others).</value>
   </data>
   <data name="lblPublished.Text" xml:space="preserve">
-    <value>Published</value>
+    <value>Is Visible</value>
   </data>
   <data name="cmdImageRemove.Text" xml:space="preserve">
     <value>Remove Image</value>

--- a/Components/Entities/Posts/PostInfo_Interfaces.vb
+++ b/Components/Entities/Posts/PostInfo_Interfaces.vb
@@ -118,8 +118,10 @@ Namespace Entities.Posts
      Return Me.Summary.OutputHtml(strFormat)
     Case "image"
      Return PropertyAccess.FormatString(Me.Image, strFormat)
-    Case "published"
+    Case "isvisible"
      Return Me.Published.ToString
+    Case "published"
+     Return (Me.Published AndAlso Me.PublishedOnDate < DateTime.UtcNow).ToString()
     Case "publishedyesno"
      Return PropertyAccess.Boolean2LocalizedYesNo(Me.Published, formatProvider)
     Case "publishedondate"


### PR DESCRIPTION
We need to show the unpublished icon if the blog is published in the future or the is visible flag is unset. This pull request relabels the old published token to isVisible and then we check for PublishedOnDate and isVisible in the new published token.