### PR TITLE
Fix blog chooser looking to wrong module

### DIFF
--- a/Controls/ManagementPanel.ascx
+++ b/Controls/ManagementPanel.ascx
@@ -141,7 +141,7 @@
 		 open: function (e) {
 		  $('.ui-dialog-buttonpane').find('button:contains("<%=LocalizeJSString("cmdBlog") %>")').addClass('dnnPrimaryAction');
 		  $('.ui-dialog-buttonpane').find('button:contains("<%=LocalizeJSString("Cancel") %>")').addClass('dnnSecondaryAction');
-    $('#ddBlog').width("100%");
+    $('#<%:ClientID%>ddBlog').width("100%");
 		 },
 		 buttons: [
     {
@@ -160,7 +160,7 @@
       } else {
        url += '&'
       };
-      url += 'Blog=' + $('#ddBlog').val();
+      url += 'Blog=' + $('#<%:ClientID%>ddBlog').val();
       window.location.href = encodeURI(url);
      }
     }
@@ -179,7 +179,7 @@
    } else {
     url += '&'
    };
-   url += 'Blog=' + $('#ddBlog').val();
+   url += 'Blog=' + $('#<%:ClientID%>ddBlog').val();
    window.location.href = encodeURI(url);
    return false;
   });

--- a/Controls/ManagementPanel.ascx.vb
+++ b/Controls/ManagementPanel.ascx.vb
@@ -83,7 +83,7 @@ Namespace Controls
    End If
    If Not String.IsNullOrEmpty(BlogContext.ShowLocale) Then RssLink &= String.Format("&language={0}", BlogContext.ShowLocale)
    If BlogContext.Security.CanAddPost Then
-    BlogSelectListHtml = "<select id=""ddBlog"">"
+    BlogSelectListHtml = "<select id=""" & ClientID & "ddBlog"">"
     Dim blogList As IEnumerable(Of BlogInfo) = Nothing
     If BlogContext.Security.IsEditor Then
      blogList = BlogsController.GetBlogsByModule(Settings.ModuleId, UserId, BlogContext.Locale).Values


### PR DESCRIPTION
When multiple blog modules are on the same page, and those modules have
multiple blogs, clicking the Blog! button opens up a blog chooser, but
the blog chooser always looks to the first module's blog list because of
conflicting IDs