### PR TITLE
Only show valid parent blog modules

### DIFF
--- a/Controls/ViewSettings.ascx.vb
+++ b/Controls/ViewSettings.ascx.vb
@@ -19,6 +19,7 @@
 '
 
 Imports System.Linq
+Imports DotNetNuke.Entities.Modules
 
 Imports DotNetNuke.Modules.Blog.Common.Globals
 Imports DotNetNuke.Modules.Blog.Entities.Blogs
@@ -107,7 +108,20 @@ Namespace Controls
     End If
 
     ddBlogModuleId.Items.Clear()
-    ddBlogModuleId.DataSource = (New DotNetNuke.Entities.Modules.ModuleController).GetModulesByDefinition(PortalId, "DNNBlog.Blog")
+
+    Dim listOfValidBlogModules As List(Of ModuleInfo) = New List(Of ModuleInfo)
+    Dim tabController As DotNetNuke.Entities.Tabs.TabController = New DotNetNuke.Entities.Tabs.TabController()
+
+    For Each blogModule As ModuleInfo In (New DotNetNuke.Entities.Modules.ModuleController).GetModulesByDefinition(PortalId, "DNNBlog.Blog")
+     Dim blogPage As DotNetNuke.Entities.Tabs.TabInfo = tabController.GetTab(blogModule.TabID, PortalId, False)
+
+     Dim targetViewSetting As Common.ViewSettings = Common.ViewSettings.GetViewSettings(blogModule.TabModuleID)
+     If targetViewSetting IsNot Nothing AndAlso CBool(targetViewSetting.BlogModuleId = -1) Then
+      listOfValidBlogModules.Add(blogModule)
+     End If
+    Next
+
+    ddBlogModuleId.DataSource = listOfValidBlogModules
     ddBlogModuleId.DataBind()
     Try
      ddBlogModuleId.Items.Remove(ddBlogModuleId.Items.FindByValue(ModuleId.ToString))

--- a/Controls/ViewSettings.ascx.vb
+++ b/Controls/ViewSettings.ascx.vb
@@ -114,6 +114,7 @@ Namespace Controls
 
     For Each blogModule As ModuleInfo In (New DotNetNuke.Entities.Modules.ModuleController).GetModulesByDefinition(PortalId, "DNNBlog.Blog")
      Dim blogPage As DotNetNuke.Entities.Tabs.TabInfo = tabController.GetTab(blogModule.TabID, PortalId, False)
+     blogModule.ModuleTitle = String.Concat(blogPage.TabName, " - ", blogModule.ModuleTitle)
 
      Dim targetViewSetting As Common.ViewSettings = Common.ViewSettings.GetViewSettings(blogModule.TabModuleID)
      If targetViewSetting IsNot Nothing AndAlso CBool(targetViewSetting.BlogModuleId = -1) Then

--- a/Controls/ViewSettings.ascx.vb
+++ b/Controls/ViewSettings.ascx.vb
@@ -117,13 +117,14 @@ Namespace Controls
      blogModule.ModuleTitle = String.Concat(blogPage.TabName, " - ", blogModule.ModuleTitle)
 
      Dim targetViewSetting As Common.ViewSettings = Common.ViewSettings.GetViewSettings(blogModule.TabModuleID)
-     If targetViewSetting IsNot Nothing AndAlso CBool(targetViewSetting.BlogModuleId = -1) Then
+     If CBool(targetViewSetting.BlogModuleId = -1) Then
       listOfValidBlogModules.Add(blogModule)
      End If
     Next
 
     ddBlogModuleId.DataSource = listOfValidBlogModules
     ddBlogModuleId.DataBind()
+
     Try
      ddBlogModuleId.Items.Remove(ddBlogModuleId.Items.FindByValue(ModuleId.ToString))
     Catch ex As Exception


### PR DESCRIPTION
When building out a site with multiple blogs and using the parent blog module setting, invalid instances of the blog module would appear in the settings list. This pull request removes any modules which are configured to use another blog instance as it's parent. We're also adding the Page Name to the text in the drop down to make it slightly easier to identify which instance is targeted. 