### PR TITLE
Ensure all cache keys are prefixed with "Blog"

### DIFF
--- a/Components/Common/ModuleSettings.vb
+++ b/Components/Common/ModuleSettings.vb
@@ -125,7 +125,7 @@ Namespace Common
   End Sub
 
   Public Shared Function GetModuleSettings(moduleId As Integer) As ModuleSettings
-   Dim CacheKey As String = "ModuleSettings" & moduleId.ToString
+   Dim CacheKey As String = "Blog_ModuleSettings" & moduleId.ToString
    Dim settings As ModuleSettings = CType(DotNetNuke.Common.Utilities.DataCache.GetCache(CacheKey), ModuleSettings)
    If settings Is Nothing Then
     settings = New ModuleSettings(moduleId)
@@ -162,7 +162,7 @@ Namespace Common
    objModules.UpdateModuleSetting(_moduleId, "IncrementViewCount", IncrementViewCount.ToString)
    If _importedModuleId > -1 Then objModules.UpdateModuleSetting(_moduleId, "ImportedModuleID", _importedModuleId.ToString)
 
-   Dim CacheKey As String = "ModuleSettings" & _moduleId.ToString
+   Dim CacheKey As String = "Blog_ModuleSettings" & _moduleId.ToString
    DotNetNuke.Common.Utilities.DataCache.SetCache(CacheKey, Me)
   End Sub
 #End Region

--- a/Components/Common/ViewSettings.vb
+++ b/Components/Common/ViewSettings.vb
@@ -104,7 +104,7 @@ Namespace Common
   End Sub
 
   Public Shared Function GetViewSettings(tabModuleId As Integer) As ViewSettings
-   Dim CacheKey As String = "TabModuleSettings" & tabModuleId.ToString
+   Dim CacheKey As String = "Blog_TabModuleSettings" & tabModuleId.ToString
    Dim settings As ViewSettings = CType(DotNetNuke.Common.Utilities.DataCache.GetCache(CacheKey), ViewSettings)
    If settings Is Nothing Then
     settings = New ViewSettings(tabModuleId)
@@ -135,7 +135,7 @@ Namespace Common
    objModules.UpdateTabModuleSetting(tabModuleId, "AuthorId", AuthorId.ToString)
    _categoryList = Nothing
 
-   Dim CacheKey As String = "TabModuleSettings" & tabModuleId.ToString
+   Dim CacheKey As String = "Blog_TabModuleSettings" & tabModuleId.ToString
    DotNetNuke.Common.Utilities.DataCache.SetCache(CacheKey, Me)
 
   End Sub
@@ -145,7 +145,7 @@ Namespace Common
    For Each key As String In TemplateSettings.Keys
     objModules.UpdateTabModuleSetting(_tabModuleId, "t_" & key, TemplateSettings(key))
    Next
-   Dim CacheKey As String = "TabModuleSettings" & _tabModuleId.ToString
+   Dim CacheKey As String = "Blog_TabModuleSettings" & _tabModuleId.ToString
    DotNetNuke.Common.Utilities.DataCache.SetCache(CacheKey, Me)
   End Sub
 

--- a/Components/Integration/BlogModuleController_Portable.vb
+++ b/Components/Integration/BlogModuleController_Portable.vb
@@ -35,7 +35,7 @@ Namespace Integration
 
 #Region " Post Import Logic "
   Public Shared Sub CheckupOnImportedFiles(moduleId As Integer)
-   Dim CacheKey As String = "CheckupOnImportedFiles" & moduleId.ToString
+   Dim CacheKey As String = "Blog_CheckupOnImportedFiles" & moduleId.ToString
    If DotNetNuke.Common.Utilities.DataCache.GetCache(CacheKey) Is Nothing Then
     Dim logFile As String = String.Format(LogFilePattern, DotNetNuke.Common.HostMapPath, moduleId)
     If IO.File.Exists(logFile) Then

--- a/Components/Templating/BaseTokenReplace.vb
+++ b/Components/Templating/BaseTokenReplace.vb
@@ -67,9 +67,9 @@ Namespace Templating
   Private ReadOnly Property TokenReplaceCacheKey() As String
    Get
     If UseObjectLessExpression Then
-     Return "TokenReplaceRegEx_Objectless"
+     Return "Blog_TokenReplaceRegEx_Objectless"
     Else
-     Return "TokenReplaceRegEx_Default"
+     Return "Blog_TokenReplaceRegEx_Default"
     End If
    End Get
   End Property


### PR DESCRIPTION
The `"ModuleSettings"` and `"TabModuleSettings"` cache keys are also used by DNN core,
so there were cases where a conflict would happen and the Blog would throw an
exception trying to get the Dictionary that the core put into the cache and use
it as a `ViewSettings` or `ModuleSettings` object.

See http://www.luiscabrera.me/Blog/Post/1107 as an example of where this has happened (notice that when passing `-1` as the ID, an empty `Dictionary` comes back, rather than `Nothing`).  The fix in that post addressed a separate issue.  The reason this doesn't show up all of the time is because the IDs used between this module and the core are different (i.e. the blog module appends _tab module ID_ and _module ID_ to the cache keys, while DNN appends _tab ID_ in both cases, so the conflict isn't direct and immediate.